### PR TITLE
server: harden TLS handshake and accept loop error handling

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -4,6 +4,8 @@
 use std::time::Duration;
 
 const DEFAULT_HTTP2_KEEPALIVE_TIMEOUT_SECS: u64 = 20;
+const DEFAULT_TLS_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(5);
+const DEFAULT_MAX_PENDING_CONNECTIONS: usize = 4096;
 
 #[derive(Debug, Clone)]
 pub struct Config {
@@ -21,7 +23,8 @@ pub struct Config {
     pub(crate) accept_http1: bool,
     enable_connect_protocol: bool,
     pub(crate) max_connection_age: Option<Duration>,
-    pub(crate) allow_insecure: bool,
+    pub(crate) tls_handshake_timeout: Duration,
+    pub(crate) max_pending_connections: usize,
 }
 
 impl Default for Config {
@@ -41,7 +44,8 @@ impl Default for Config {
             accept_http1: true,
             enable_connect_protocol: true,
             max_connection_age: None,
-            allow_insecure: false,
+            tls_handshake_timeout: DEFAULT_TLS_HANDSHAKE_TIMEOUT,
+            max_pending_connections: DEFAULT_MAX_PENDING_CONNECTIONS,
         }
     }
 }
@@ -197,17 +201,27 @@ impl Config {
         }
     }
 
-    /// Allow accepting insecure connections when a tls_config is provided.
+    /// Sets the timeout for TLS handshakes on incoming connections.
     ///
-    /// This will allow clients to connect both using TLS as well as without TLS on the same
-    /// network interface.
+    /// Connections that do not complete the TLS handshake within this duration are dropped.
     ///
-    /// Default is `false`.
-    ///
-    /// NOTE: This presently will only work for `tokio::net::TcpStream` IO connections
-    pub fn allow_insecure(self, allow_insecure: bool) -> Self {
+    /// Default is 5 seconds.
+    pub fn tls_handshake_timeout(self, timeout: Duration) -> Self {
         Config {
-            allow_insecure,
+            tls_handshake_timeout: timeout,
+            ..self
+        }
+    }
+
+    /// Sets the maximum number of pending TLS handshakes.
+    ///
+    /// When this limit is reached, new incoming connections are dropped until existing
+    /// handshakes complete or time out.
+    ///
+    /// Default is 4096.
+    pub fn max_pending_connections(self, max: usize) -> Self {
+        Config {
+            max_pending_connections: max,
             ..self
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -292,33 +292,23 @@ where
 
     fn handle_incomming(&mut self, io: L::Io, remote_addr: L::Addr) {
         if let Some(tls) = self.tls_config.clone() {
-            let tls_acceptor = TlsAcceptor::from(tls);
-            let allow_insecure = self.config.allow_insecure;
-            self.pending_connections.spawn(async move {
-                if allow_insecure {
-                    // XXX: If we want to allow for supporting insecure traffic from other types of
-                    // io, we'll need to implement a generic peekable IO type
-                    if let Some(tcp) =
-                        <dyn std::any::Any>::downcast_ref::<tokio::net::TcpStream>(&io)
-                    {
-                        // Determine whether new connection is TLS.
-                        let mut buf = [0; 1];
-                        // `peek` blocks until at least some data is available, so if there is no error then
-                        // it must return the one byte we are requesting.
-                        tcp.peek(&mut buf).await?;
-                        // First byte of a TLS handshake is 0x16, so if it isn't 0x16 then its
-                        // insecure
-                        if buf != [0x16] {
-                            tracing::trace!("accepting insecure connection");
-                            return Ok((ServerIo::new_io(io), remote_addr));
-                        }
-                    } else {
-                        tracing::warn!("'allow_insecure' is configured but io type is not 'tokio::net::TcpStream'");
-                    }
-                }
+            if self.pending_connections.len() >= self.config.max_pending_connections {
+                tracing::warn!(
+                    pending = self.pending_connections.len(),
+                    "max pending connections reached, dropping new connection"
+                );
+                return;
+            }
 
+            let tls_acceptor = TlsAcceptor::from(tls);
+            let timeout_duration = self.config.tls_handshake_timeout;
+            self.pending_connections.spawn(async move {
                 tracing::trace!("accepting TLS connection");
-                let io = tls_acceptor.accept(io).await?;
+                let io = tokio::time::timeout(timeout_duration, tls_acceptor.accept(io))
+                    .await
+                    .map_err(|_| {
+                        std::io::Error::new(std::io::ErrorKind::TimedOut, "TLS handshake timed out")
+                    })??;
                 Ok((ServerIo::new_tls_io(io), remote_addr))
             });
         } else {

--- a/src/listener.rs
+++ b/src/listener.rs
@@ -61,10 +61,11 @@ impl Listener for tokio::net::TcpListener {
     type Addr = std::net::SocketAddr;
 
     async fn accept(&mut self) -> (Self::Io, Self::Addr) {
+        let mut backoff = AcceptBackoff::new();
         loop {
             match Self::accept(self).await {
                 Ok(tup) => return tup,
-                Err(e) => handle_accept_error(e).await,
+                Err(e) => backoff.handle_accept_error(e).await,
             }
         }
     }
@@ -200,24 +201,41 @@ where
     }
 }
 
-async fn handle_accept_error(e: std::io::Error) {
-    if is_connection_error(&e) {
-        return;
+/// Exponential backoff for recoverable `accept()` errors.
+///
+/// Certain errors (notably `EMFILE`/`ENFILE`, when the process has exhausted its
+/// file descriptor limit) leave the listener in a persistently-readable state,
+/// causing `accept()` to return immediately on retry. Without backoff the serve
+/// loop would spin a CPU core and flood logs.
+///
+/// A fixed 1 second sleep (as in hyper 0.14 and still in axum today) avoids the
+/// spin but delays recovery once descriptors free up. Instead we follow Go's
+/// `net/http` and HashiCorp Vault: start at 5ms and double on each consecutive
+/// error, capped at 1 second. Reset-on-success is implicit because a fresh
+/// `AcceptBackoff` is constructed per call to `accept()`.
+struct AcceptBackoff {
+    next_delay: Duration,
+}
+
+impl AcceptBackoff {
+    const MIN: Duration = Duration::from_millis(5);
+    const MAX: Duration = Duration::from_secs(1);
+
+    fn new() -> Self {
+        Self {
+            next_delay: Self::MIN,
+        }
     }
 
-    // [From `hyper::Server` in 0.14](https://github.com/hyperium/hyper/blob/v0.14.27/src/server/tcp.rs#L186)
-    //
-    // > A possible scenario is that the process has hit the max open files
-    // > allowed, and so trying to accept a new connection will fail with
-    // > `EMFILE`. In some cases, it's preferable to just wait for some time, if
-    // > the application will likely close some files (or connections), and try
-    // > to accept the connection again. If this option is `true`, the error
-    // > will be logged at the `error` level, since it is still a big deal,
-    // > and then the listener will sleep for 1 second.
-    //
-    // hyper allowed customizing this but axum does not.
-    tracing::error!("accept error: {e}");
-    tokio::time::sleep(Duration::from_secs(1)).await;
+    async fn handle_accept_error(&mut self, e: std::io::Error) {
+        if is_connection_error(&e) {
+            return;
+        }
+
+        tracing::error!(backoff = ?self.next_delay, "accept error: {e}");
+        tokio::time::sleep(self.next_delay).await;
+        self.next_delay = (self.next_delay * 2).min(Self::MAX);
+    }
 }
 
 fn is_connection_error(e: &std::io::Error) -> bool {


### PR DESCRIPTION
Previously, the server exposed an allow_insecure option that peeked at the first byte of each connection to route plain-text traffic alongside TLS on the same listener. This was a temporary compatibility shim with no way to bound the resources consumed by slow or malicious TLS handshakes. With this commit, allow_insecure is removed and replaced with two new Config options:

- `tls_handshake_timeout` (default 5s): bounds the time a TLS handshake may take before the connection is dropped.
- `max_pending_connections` (default 4096): caps the number of in-flight TLS handshakes; new connections are dropped once the cap is reached.

Additionally, the fixed 1s sleep on `accept()` errors is replaced with exponential backoff starting at 5ms and capped at 1s, resetting on success. The 1s delay was inherited from hyper 0.14 and is still used by axum; it avoids a spin loop on EMFILE/ENFILE but delays recovery once file descriptors free up. The new sequence matches Go's `net/http` and HashiCorp Vault.